### PR TITLE
Herokuに対応

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm:
-  - 2.2.4
+  - 2.3.3
 services:
   - mysql
 bundler_args: "--without development --deployment"

--- a/Dockerfile.base
+++ b/Dockerfile.base
@@ -15,14 +15,14 @@ RUN apt-get update && \
     libxslt1-dev \
     libyaml-dev \
     zlib1g-dev && \
-    curl -O http://ftp.ruby-lang.org/pub/ruby/2.1/ruby-2.1.2.tar.gz && \
-    tar -zxvf ruby-2.1.2.tar.gz && \
-    cd ruby-2.1.2 && \
+    curl -O http://ftp.ruby-lang.org/pub/ruby/2.3/ruby-2.3.3.tar.gz && \
+    tar -zxvf ruby-2.3.3.tar.gz && \
+    cd ruby-2.3.3 && \
     ./configure --disable-install-doc && \
     make && \
     make install && \
     cd .. && \
-    rm -r ruby-2.1.2 ruby-2.1.2.tar.gz && \
+    rm -r ruby-2.3.3 ruby-2.3.3.tar.gz && \
     echo 'gem: --no-document' > /usr/local/etc/gemrc
 
 # Install Bundler for each version of ruby

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # coding: utf-8
 source 'https://rubygems.org'
 
-ruby '2.3'
+ruby '~> 2.3.0'
 
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.8'

--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,8 @@
 # coding: utf-8
 source 'https://rubygems.org'
 
+ruby '2.3'
+
 # Bundle edge Rails instead: gem 'rails', github: 'rails/rails'
 gem 'rails', '4.2.8'
 # Use sqlite3 as the database for Active Record

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -289,5 +289,8 @@ DEPENDENCIES
   uglifier (>= 1.3.0)
   web-console (~> 2.0)
 
+RUBY VERSION
+   ruby 2.3.3p222
+
 BUNDLED WITH
    1.14.3


### PR DESCRIPTION
すみませんこちらのテスト環境、Herokuで動かなくなってしまいました。
原因は、Heroku上でRubyバージョン未指定だとRuby2.0が使用され、
バージョンのあがったGEMがRuby2.1以上を要求するためでした。

よって2.3.3を使うように明示しました。

このプルリクが処理されたら、CfKのほうでもマージいたします。
